### PR TITLE
feat!: removed public ip from the module itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | Name | Type |
 |------|------|
 | [azurerm_bastion_host.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/bastion_host) | resource |
-| [azurerm_public_ip.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
@@ -63,7 +61,6 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | Name | Description |
 |------|-------------|
 | <a name="output_host"></a> [host](#output\_host) | contains all bastion related configuration |
-| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | contains the current subscription id |
 <!-- END_TF_DOCS -->
 
 ## Testing

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -16,7 +16,8 @@ host = object({
   shareable_link_enabled  = optional(bool, false)
   kerberos_enabled        = optional(bool, false)
   ip_configuration = object({
-    subnet_id = string
+    subnet_id            = string
+    public_ip_address_id = string
   })
 })
 ```

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -41,11 +41,26 @@ module "network" {
   }
 }
 
-module "bastion" {
-  source  = "cloudnationhq/bastion/azure"
+module "public_ip" {
+  source  = "cloudnationhq/pip/azure"
   version = "~> 2.0"
 
   naming = local.naming
+
+  configs = {
+    bastion = {
+      name           = module.naming.public_ip.name
+      location       = module.rg.groups.demo.location
+      resource_group = module.rg.groups.demo.name
+
+      zones = ["1", "2", "3"]
+    }
+  }
+}
+
+module "bastion" {
+  source  = "cloudnationhq/bastion/azure"
+  version = "~> 3.0"
 
   host = {
     name           = module.naming.bastion_host.name_unique
@@ -60,7 +75,8 @@ module "bastion" {
     kerberos_enabled       = true
 
     ip_configuration = {
-      subnet_id = module.network.subnets.bastion.id
+      subnet_id            = module.network.subnets.bastion.id
+      public_ip_address_id = module.public_ip.configs.bastion.id
     }
   }
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,8 +1,0 @@
-output "bastion" {
-  value     = module.bastion.host
-  sensitive = true
-}
-
-output "subscription_id" {
-  value = module.bastion.subscription_id
-}

--- a/examples/complete/rules.tf
+++ b/examples/complete/rules.tf
@@ -11,28 +11,6 @@ locals {
       source_address_prefix      = "Internet"
       destination_address_prefix = "*"
     },
-    allow_bastion_communication = {
-      name                       = "AllowBastionCommunication"
-      priority                   = 120
-      direction                  = "Outbound"
-      access                     = "Allow"
-      protocol                   = "*"
-      source_port_range          = "*"
-      source_address_prefix      = "VirtualNetwork"
-      destination_address_prefix = "VirtualNetwork"
-      destination_port_ranges    = ["8080", "5701"]
-    },
-    allow_ssh_rdp_outbound = {
-      name                       = "AllowSshRdpOutbound"
-      priority                   = 100
-      direction                  = "Outbound"
-      access                     = "Allow"
-      protocol                   = "*"
-      source_port_range          = "*"
-      source_address_prefix      = "*"
-      destination_address_prefix = "VirtualNetwork"
-      destination_port_ranges    = ["22", "3389"]
-    },
     allow_gateway_manager_inbound = {
       name                       = "AllowGatewayManagerInbound"
       priority                   = 130
@@ -44,6 +22,39 @@ locals {
       source_address_prefix      = "GatewayManager"
       destination_address_prefix = "*"
     },
+    allow_load_balancer_inbound = {
+      name                       = "AllowLoadBalancerInbound"
+      priority                   = 140
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "443"
+      source_address_prefix      = "AzureLoadBalancer"
+      destination_address_prefix = "*"
+    },
+    allow_bastion_host_communication_inbound = {
+      name                       = "AllowBastionHostCommunication"
+      priority                   = 150
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "*"
+      source_port_range          = "*"
+      destination_port_ranges    = ["8080", "5701"]
+      source_address_prefix      = "VirtualNetwork"
+      destination_address_prefix = "VirtualNetwork"
+    },
+    allow_ssh_rdp_outbound = {
+      name                       = "AllowSshRdpOutbound"
+      priority                   = 100
+      direction                  = "Outbound"
+      access                     = "Allow"
+      protocol                   = "*"
+      source_port_range          = "*"
+      destination_port_ranges    = ["22", "3389"]
+      source_address_prefix      = "*"
+      destination_address_prefix = "VirtualNetwork"
+    },
     allow_azure_cloud_outbound = {
       name                       = "AllowAzureCloudOutbound"
       priority                   = 110
@@ -54,6 +65,17 @@ locals {
       destination_port_range     = "443"
       source_address_prefix      = "*"
       destination_address_prefix = "AzureCloud"
+    },
+    allow_bastion_host_communication_outbound = {
+      name                       = "AllowBastionCommunication"
+      priority                   = 120
+      direction                  = "Outbound"
+      access                     = "Allow"
+      protocol                   = "*"
+      source_port_range          = "*"
+      destination_port_ranges    = ["8080", "5701"]
+      source_address_prefix      = "VirtualNetwork"
+      destination_address_prefix = "VirtualNetwork"
     },
     allow_get_session_information = {
       name                       = "AllowGetSessionInformation"

--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,3 @@
-data "azurerm_subscription" "current" {}
-
-# public ip
-resource "azurerm_public_ip" "pip" {
-  name                    = try(var.host.public_ip.name, var.naming.public_ip)
-  resource_group_name     = coalesce(lookup(var.host, "resource_group", null), var.resource_group)
-  location                = coalesce(lookup(var.host, "location", null), var.location)
-  allocation_method       = try(var.host.public_ip.allocation_method, "Static")
-  sku                     = try(var.host.public_ip.sku, "Standard")
-  zones                   = try(var.host.public_ip.zones, [1, 2, 3])
-  public_ip_prefix_id     = try(var.host.public_ip.public_ip_prefix_id, null)
-  sku_tier                = try(var.host.public_ip.sku_tier, "Regional")
-  edge_zone               = try(var.host.public_ip.edge_zone, null)
-  ip_version              = try(var.host.public_ip.ip_version, "IPv4")
-  reverse_fqdn            = try(var.host.public_ip.reverse_fqdn, null)
-  domain_name_label       = try(var.host.public_ip.domain_name_label, null)
-  ddos_protection_mode    = try(var.host.public_ip.ddos_protection_mode, "VirtualNetworkInherited")
-  ddos_protection_plan_id = try(var.host.public_ip.ddos_protection_plan_id, null)
-  idle_timeout_in_minutes = try(var.host.public_ip.idle_timeout_in_minutes, null)
-  ip_tags                 = try(var.host.public_ip.ip_tags, null)
-  tags                    = try(var.host.public_ip.tags, var.tags, null)
-}
-
 # bastion host
 resource "azurerm_bastion_host" "bastion" {
   name                = try(var.host.name, var.naming.bastion_host)
@@ -38,10 +15,11 @@ resource "azurerm_bastion_host" "bastion" {
   session_recording_enabled = try(var.host.session_recording_enabled, false)
   zones                     = try(var.host.zones, [])
   tags                      = try(var.host.tags, var.tags, null)
+  virtual_network_id        = try(var.host.virtual_network_id, null)
 
   ip_configuration {
     name                 = try(var.host.ip_configuration.name, "configuration")
     subnet_id            = var.host.ip_configuration.subnet_id
-    public_ip_address_id = try(var.host.ip_configuration.public_ip_address_id, azurerm_public_ip.pip.id)
+    public_ip_address_id = var.host.ip_configuration.public_ip_address_id
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,8 +2,3 @@ output "host" {
   description = "contains all bastion related configuration"
   value       = azurerm_bastion_host.bastion
 }
-
-output "subscription_id" {
-  description = "contains the current subscription id"
-  value       = data.azurerm_subscription.current.subscription_id
-}


### PR DESCRIPTION
BREAKING CHANGE: public ip needs to be used as a separated module.

## Description

The PR removed the public ip resource from this module, as it needs to be a separate module

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


```
    deploy_test.go:192: Cleaning up in: ../examples/complete
--- PASS: TestApplyNoError (1081.20s)
PASS
ok      github.com/cloudnationhq/terraform-azure-bastion        1081.615s

```

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #59